### PR TITLE
Formatted options as post-encode arguments (to beta)

### DIFF
--- a/VidCoder/Resources/PickerRes.Designer.cs
+++ b/VidCoder/Resources/PickerRes.Designer.cs
@@ -286,6 +286,15 @@ namespace VidCoder.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Available options: {0}.
+        /// </summary>
+        public static string OverrideNameFormatLabel {
+            get {
+                return ResourceManager.GetString("OverrideNameFormatLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Picker: {0}.
         /// </summary>
         public static string PickerButtonFormat {
@@ -313,7 +322,7 @@ namespace VidCoder.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The arguments to pass to the program. Use {file} for the file output path..
+        ///   Looks up a localized string similar to The arguments to pass to the program. Use {file} for the file output path, {folder} as containing folder path or other path options like {title} and {date} (see Naming Format)..
         /// </summary>
         public static string PostEncodeArgumentsToolTip {
             get {

--- a/VidCoder/Resources/PickerRes.resx
+++ b/VidCoder/Resources/PickerRes.resx
@@ -191,7 +191,7 @@
     <comment>The label for the arguments to pass to the post-encode executable.</comment>
   </data>
   <data name="PostEncodeArgumentsToolTip" xml:space="preserve">
-    <value>The arguments to pass to the program. Use {file} for the file output path.</value>
+    <value>The arguments to pass to the program. Use {file} for the file output path, {folder} as containing folder path or other path options like {title} and {date} (see Naming Format).</value>
     <comment>Tool tip for the post-encode arguments UI. Do not translate {file} .</comment>
   </data>
   <data name="PresetDisabledForPickerToolTip" xml:space="preserve">
@@ -258,5 +258,8 @@
   </data>
   <data name="SubtitleLastSelectedToolTip" xml:space="preserve">
     <value>Picks the last selected subtitle track if a match is found, otherwise or no tracks.</value>
+  </data>
+  <data name="OverrideNameFormatLabel" xml:space="preserve">
+    <value>Available options: {0}</value>
   </data>
 </root>

--- a/VidCoder/Services/ProcessingService.cs
+++ b/VidCoder/Services/ProcessingService.cs
@@ -1563,7 +1563,9 @@ namespace VidCoder.Services
 					var picker = this.pickersService.SelectedPicker.Picker;
 					if (status == EncodeResultStatus.Succeeded && picker.PostEncodeActionEnabled && !string.IsNullOrWhiteSpace(picker.PostEncodeExecutable))
 					{
-						string arguments = picker.PostEncodeArguments.Replace("{file}", outputPath);
+						string arguments = outputVM.ReplaceArguments(picker.PostEncodeArguments, picker)
+                            .Replace("{file}", outputPath)
+                            .Replace("{folder}", Path.GetDirectoryName(outputPath));
 
 						var process = new ProcessStartInfo(
 							picker.PostEncodeExecutable,

--- a/VidCoder/View/PickerWindow.xaml
+++ b/VidCoder/View/PickerWindow.xaml
@@ -242,6 +242,13 @@
 								               Mode=TwoWay,
 								               UpdateSourceTrigger=PropertyChanged}" />
 						</Grid>
+
+						<TextBlock 
+							Margin="22 2 0 10"
+							Visibility="{Binding NameFormatOverrideEnabled,
+								                     Converter={StaticResource VisibilityConverter}}"
+							Text="{Binding NameFormatArguments, StringFormat={x:Static res:PickerRes.OverrideNameFormatLabel}}"
+							TextWrapping="Wrap" />
 						<CheckBox
 							Height="16"
 							Margin="0 6 0 0"

--- a/VidCoder/ViewModel/PickerWindowViewModel.cs
+++ b/VidCoder/ViewModel/PickerWindowViewModel.cs
@@ -306,6 +306,8 @@ namespace VidCoder.ViewModel
 			}
 		}
 
+		public string NameFormatArguments { get { return "{source} {title} {range} {preset} {date} {time} {quality} {parent} {titleduration}"; } }
+
 		private void PopulateEncodingPreset(bool useEncodingPreset)
 		{
 			if (useEncodingPreset)


### PR DESCRIPTION
Added possibility to use formatted options as post-encode arguments.
There are two commits: first one with business logic and second one with few UI tweaks (not important).