### PR TITLE
Use vswhere.exe to find the location of msbuild instead of a hard-coded path

### DIFF
--- a/build_common.ps1
+++ b/build_common.ps1
@@ -84,5 +84,6 @@ function DeleteFileIfExists($fileName)
     if (Test-Path $fileName) { Remove-Item $fileName }
 }
 
-$VSFolder = "C:\Program Files\Microsoft Visual Studio\2022\Community"
-$MsBuildExe = "$VSFolder\Msbuild\Current\Bin\MSBuild.exe"
+# vswhere.exe is documented to have a consistent install location, no matter the version or edition of VS that is installed.
+$MSBuildPath = (&"${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe) | Out-String
+Set-Alias msbuild $MSBuildPath.Trim()

--- a/build_interop.ps1
+++ b/build_interop.ps1
@@ -11,7 +11,7 @@ $HandBrakeInteropFolder = $HandBrakeFolder + "\HandBrake.Interop"
 $HandBrakeInteropProject = $HandBrakeInteropFolder + "\HandBrake.Interop.csproj"
 $HandBrakeInteropBinFolder = $HandBrakeInteropFolder + "\bin\Any CPU\Release";
 
-& $MsBuildExe $HandBrakeInteropProject /t:rebuild "/p:Configuration=Release;Platform=Any CPU"; ExitIfFailed
+msbuild $HandBrakeInteropProject /t:rebuild "/p:Configuration=Release;Platform=Any CPU"; ExitIfFailed
 copy ($HandBrakeInteropBinFolder + "\HandBrake.Interop.dll") Lib -force
 copy ($HandBrakeInteropBinFolder + "\HandBrake.Interop.pdb") Lib -force
 "Files copied."


### PR DESCRIPTION
Minor update to the build script to use vswhere.exe to locate msbuild.exe instead of relying on VS 2022 Community specifically being installed. 